### PR TITLE
Add pluggable EnvLookup interface for embedded scenarios (v1.0.0)

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -20,3 +20,9 @@ type ConfigStoreGetter interface {
 	ContextValueGetter
 	ProjectEnvIDSupplier
 }
+
+// EnvLookup defines the interface for looking up environment variables.
+// This allows the SDK to be used in embedded scenarios where direct environment access should be disabled.
+type EnvLookup interface {
+	LookupEnv(key string) (string, bool)
+}

--- a/internal/config_resolver.go
+++ b/internal/config_resolver.go
@@ -132,7 +132,7 @@ func (c ConfigResolver) ResolveValueForConfig(config *prefabProto.Config, contex
 func (c ConfigResolver) handleProvided(provided *prefabProto.Provided) (string, bool) {
 	if provided.GetSource() == prefabProto.ProvidedSource_ENV_VAR {
 		if provided.Lookup != nil {
-			envValue, envValueExists := os.LookupEnv(provided.GetLookup())
+			envValue, envValueExists := c.EnvLookup.LookupEnv(provided.GetLookup())
 
 			return envValue, envValueExists
 		}

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	APIURLs                      []string
 	Sources                      []ConfigSource
 	CustomStores                 []interface{} // ConfigStoreGetter implementations
+	CustomEnvLookup              interface{}   // EnvLookup implementation
 	EnvironmentNames             []string
 	ProjectEnvID                 int64
 	InitializationTimeoutSeconds float64

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,5 +1,5 @@
 package internal
 
-const Version = "0.3.1"
+const Version = "1.0.0"
 
 const ClientVersionHeader = "sdk-go-" + Version

--- a/option_helpers.go
+++ b/option_helpers.go
@@ -213,3 +213,20 @@ func WithCustomStore(store ConfigStoreGetter) Option {
 		return nil
 	}
 }
+
+// WithEnvLookup provides a custom environment variable lookup implementation.
+// This is useful for embedded scenarios where direct environment access should be disabled.
+// The default behavior uses os.LookupEnv.
+//
+// Example (disable environment variable access):
+//
+//	type NoOpEnvLookup struct{}
+//	func (n *NoOpEnvLookup) LookupEnv(key string) (string, bool) { return "", false }
+//
+//	client, err := reforge.NewSdk(reforge.WithEnvLookup(&NoOpEnvLookup{}))
+func WithEnvLookup(envLookup EnvLookup) Option {
+	return func(o *options.Options) error {
+		o.CustomEnvLookup = envLookup
+		return nil
+	}
+}

--- a/sdk.go
+++ b/sdk.go
@@ -140,6 +140,13 @@ func NewSdk(opts ...Option) (*Client, error) {
 
 	configResolver := internal.NewConfigResolver(configStore)
 
+	// Apply custom EnvLookup if provided
+	if options.CustomEnvLookup != nil {
+		if envLookup, ok := options.CustomEnvLookup.(internal.EnvLookup); ok {
+			configResolver.EnvLookup = envLookup
+		}
+	}
+
 	client = Client{
 		options:                &options,
 		configStore:            configStore,


### PR DESCRIPTION
## Summary

- Adds pluggable `EnvLookup` interface for embedded scenarios where environment variable access should be controlled
- Fixes bug where `handleProvided` was calling `os.LookupEnv` directly instead of using the pluggable interface
- Adds `WithEnvLookup` option to configure custom environment lookup
- Bumps version to 1.0.0

This brings the Go SDK to feature parity with the Java SDK's ConfigResolver pattern, enabling the SDK to be used in embedded environments.

## Changes

### Bug Fix
- **internal/config_resolver.go:135** - Fixed `handleProvided` to use `c.EnvLookup.LookupEnv` instead of direct `os.LookupEnv` call

### New Features
- **interfaces.go** - Added public `EnvLookup` interface
- **option_helpers.go** - Added `WithEnvLookup` option with documentation
- **internal/options/options.go** - Added `CustomEnvLookup` field to Options
- **sdk.go** - Wired custom EnvLookup in SDK initialization

### Tests
- **internal/config_resolver_test.go** - Added `TestConfigResolver_CustomEnvLookup` and `TestConfigResolver_CustomEnvLookupReturnsNotFound`
- Fixed existing tests to properly initialize `EnvLookup` field

### Version
- **internal/version.go** - Bumped from 0.3.1 to 1.0.0

## Usage Example

For embedded scenarios where environment variable access should be disabled:

```go
type NoOpEnvLookup struct{}
func (n *NoOpEnvLookup) LookupEnv(key string) (string, bool) { 
    return "", false 
}

client, err := reforge.NewSdk(
    reforge.WithEnvLookup(&NoOpEnvLookup{}),
)
```

**Default behavior:** Uses `os.LookupEnv` via `RealEnvLookup` (no user intervention required)

## Test plan

- [x] All existing tests pass
- [x] New tests verify custom EnvLookup works correctly
- [x] New tests verify custom EnvLookup returns proper errors when env vars don't exist
- [x] Bug fix verified by test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)